### PR TITLE
PS-420 dial down number of threads to workaround concurrency issue. Guav...

### DIFF
--- a/src/test/java/org/plos/repo/service/ObjectLockTest.java
+++ b/src/test/java/org/plos/repo/service/ObjectLockTest.java
@@ -77,10 +77,10 @@ public class ObjectLockTest extends RepoBaseSpringTest {
   @Test
   public void testReaderAndWritersSameKey() throws Exception {
 
-    final int INSERT_THREADS = 25;
-    final int UPDATE_THREADS = 100;
+    final int INSERT_THREADS = 10;
+    final int UPDATE_THREADS = 20;
     final int DELETE_THREADS = 0;
-    final int READER_THREADS = 100;
+    final int READER_THREADS = 25;
 
     Callback callback = new Callback() {
       public String getKeyname(int i) {
@@ -125,9 +125,9 @@ public class ObjectLockTest extends RepoBaseSpringTest {
   public void testReaderAndWritersSameKeyWithDeletions() throws Exception {
 
     final int INSERT_THREADS = 25;
-    final int UPDATE_THREADS = 100;
+    final int UPDATE_THREADS = 20;
     final int DELETE_THREADS = 10;
-    final int READER_THREADS = 125;
+    final int READER_THREADS = 25;
 
     Callback callback = new Callback() {
       public String getKeyname(int i) {


### PR DESCRIPTION
...a

library issues new write lock for same bucket + key under "heavy load" (ex: 100
readers and 100 updates to same key). Bug in Guava lib? Configuration? Tests run
fine with fewer threads. I still think reduced count likely still exceeds
contention in Production environment.
