### PR TITLE
DPRO-3143: Move MySQL Connector/J dependency to Maven Tomcat plugin list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,11 +147,6 @@
       <artifactId>hsqldb</artifactId>
       <version>2.3.1</version>
     </dependency>
-    <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
-      <version>5.1.12</version>
-    </dependency>
 
     <dependency>
       <groupId>org.apache.tomcat</groupId>
@@ -312,6 +307,13 @@
           <path>/</path>
           <contextFile>/etc/ambra/context.xml</contextFile>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>5.1.12</version>
+          </dependency>
+        </dependencies>
       </plugin>
 
     </plugins>


### PR DESCRIPTION
MySQL Connector/J introduces licensing issues if we compile it into the
main application binary. It should be needed only for the Tomcat plugin.