### PR TITLE
Upgrade to tomcat7 maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -289,7 +289,7 @@
 
       <plugin>
         <groupId>org.apache.tomcat.maven</groupId>
-        <artifactId>tomcat6-maven-plugin</artifactId>
+        <artifactId>tomcat7-maven-plugin</artifactId>
         <version>2.2</version>
         <configuration>
           <path>/</path>


### PR DESCRIPTION
We use tomcat 7 in production, we should upgrade the maven plugin used for testing.