### PR TITLE
Use default $HOME/ambra/config for location of context.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,7 @@
         <version>2.2</version>
         <configuration>
           <path>/</path>
-          <contextFile>/etc/ambra/context.xml</contextFile>
+          <contextFile>${ENV.home}/ambra/config/context.xml</contextFile>
         </configuration>
         <dependencies>
           <dependency>


### PR DESCRIPTION
The open source README suggests using ~/ambra/config for the `context.xml` file in rhino and wombat, but mentions that a bug that `/etc/ambra/context.xml` must be used for content repo.

This changes the hard-coded `context.xml` to `~/ambra/config` in content repo for consistence with the rest of the docs and will allow us to remove reference to the bug.