### PR TITLE
AMBR-3 debian: install content-repo in v1 context

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -334,7 +334,7 @@
                 <data>
                   <src>${project.build.directory}/${project.build.finalName}.war</src>
                   <type>file</type>
-                  <dst>/opt/plos/contentrepo/webapps/contentrepo.war</dst>
+                  <dst>/opt/plos/contentrepo/webapps/v1.war</dst>
                 </data>
 
                 <data>


### PR DESCRIPTION
By installing in `contenrepo.war`, a user will need to visit: `http://hostname:PORT/contentrepo/` to see contentrepo.

Our salt scripts all rename `contentrepo.war` to `v1.war` to listen at `http://hostname:PORT/v1/`

This is overly complicated, in my opinion. Why not simply put it in `v1.war` in the debian package and skip the salt step?

Advantages:
- Installing the debian package works properly, and we do not need to run salt afterwards to get the proper setup
- Reduces the amount of salt code
- The only point of using a `/v1/` prefix is if it is always used, so that users can know what version of the API they are connecting to. If it is not always used it kind of seems pointless.

This should be safely mergeable without any change to salt, because the salt file move will noop if not necessary, and we can remove the salt code later.