### PR TITLE
AMBR-3 Make unified debian package for local or mogile storage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,6 @@
     <maven.build.timestamp.format>yyyyMMdd</maven.build.timestamp.format>
     <build.timestamp>${maven.build.timestamp}</build.timestamp>
     <build.counter>0</build.counter>
-    <crepo.storage.location>mogile</crepo.storage.location>
   </properties>
 
   <dependencies>
@@ -320,10 +319,19 @@
               <controlDir>${project.basedir}/src/deb/control</controlDir>
               <dataSet>
 
-                <!--create a context.xml based on storage location (mogile/local)-->
                 <data>
-                  <src>src/deb/tomcat7/conf/context-${crepo.storage.location}.template.xml</src>
-                  <dst>context-template.xml</dst>
+                  <src>src/deb/tomcat7/conf/context-mogile.template.xml</src>
+                  <dst>context-mogile.template.xml</dst>
+                  <type>file</type>
+                  <mapper>
+                    <type>perm</type>
+                    <prefix>/opt/plos/contentrepo/conf</prefix>
+                  </mapper>
+                </data>
+
+                <data>
+                  <src>src/deb/tomcat7/conf/context-local.template.xml</src>
+                  <dst>context-local.template.xml</dst>
                   <type>file</type>
                   <mapper>
                     <type>perm</type>

--- a/src/deb/control/postinst
+++ b/src/deb/control/postinst
@@ -57,7 +57,7 @@ case "$1" in
 
 ########### END app-specific code ###########
 
-	process_env_template $HOME/conf/context-template.xml $HOME/conf/context.xml
+	process_env_template $HOME/conf/context-$CREPO_STORAGE_LOCATION.template.xml $HOME/conf/context.xml
 
 	process_env_template $HOME/conf/server.template.xml $HOME/conf/server.xml
 
@@ -78,4 +78,3 @@ case "$1" in
 esac
 
 service [[artifactId]] stop || true
-

--- a/src/deb/control/templates
+++ b/src/deb/control/templates
@@ -20,7 +20,7 @@ Description: The TCP port to use for Tomcat shutdown control port
 
 Template: [[artifactId]]/crepo_storage_location
 Type: string
-Default: [[crepo.storage.location]]
+Default: mogile
 Description: Valid values: "mogile","local". Local is used for local development or vagrants and data is saved on the local filestore. Mogile is used for production-like environments and uses mogile to store data.
 
 Template: [[artifactId]]/contentrepo_mogile_trackers


### PR DESCRIPTION
Previously, depending on the property `crepo.storage.location`, `mvn package`
would create a .deb package suitable for use in mogile or local storage only.
With this change, the package will honor the `CREPO_STORAGE_LOCATION`
debconf setting.