### PR TITLE
Bump version to 1.2.4-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <artifactId>contentrepo</artifactId>
   <name>content-repo</name>
   <packaging>war</packaging>
-  <version>1.2.3</version>
+  <version>1.2.4-SNAPSHOT</version>
 
   <description>Versioning content repository for PLoS data</description>
 


### PR DESCRIPTION
- Non `-SNAPSHOT` versions should only be used for releases.