### PR TITLE
Add a simple landing page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -365,6 +365,15 @@
                   </mapper>
                 </data>
 
+                <data>
+                  <src>${project.basedir}/root-index.html</src>
+                  <type>file</type>
+                  <dst>/opt/plos/contentrepo/webapps/ROOT/index.html</dst>
+                  <mapper>
+                    <type>perm</type>
+                    <filemode>755</filemode>
+                  </mapper>
+                </data>
               </dataSet>
             </configuration>
           </execution>

--- a/root-index.html
+++ b/root-index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Welcome to the contentrepo</title>
+  </head>
+  <body>
+    <p>Welcome to the contentrepo. Click <a href='/v1/docs/'>here</a> for docs.</p>
+  </body>
+</html>


### PR DESCRIPTION
It's disconcerting to visit a web service and not see anything.

Especially on recent versions of chrome where the 404 looks pretty close to the server not answering

![404](https://user-images.githubusercontent.com/22718/46113357-e5db0900-c1a2-11e8-927d-c9fe26a37744.png)

This change adds a simple landing page at the root with a link to the docs.

![crepo](https://user-images.githubusercontent.com/22718/46113441-42d6bf00-c1a3-11e8-9cd0-c6e3a5ebcfa3.png)
