### PR TITLE
Set project.build.sourceEncoding to UTF-8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
     <build.timestamp>${maven.build.timestamp}</build.timestamp>
     <build.counter>0</build.counter>
     <maven.tomcat.port>8081</maven.tomcat.port>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Eliminates the following warning:
```
[WARNING] File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
```

This should have no effect on the build itself, because it is using UTF-8 (https://teamcity.plos.org/teamcity/viewLog.html?buildId=176381&buildTypeId=Workflow_CRepo_Build&tab=buildLog&_focus=302#_state=262)
It just eliminates a warning.