### PR TITLE
Run apt-repo during `mvn install`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -396,7 +396,7 @@
         <version>0.3.0</version>
         <executions>
           <execution>
-            <phase>package</phase>
+            <phase>install</phase>
             <goals>
               <goal>apt-repo</goal>
             </goals>


### PR DESCRIPTION
This brings crepo in line with our other Java projects. It also prevents
unused .deb packages from filling up our TC build agents.

The maven apt-repo plugin is used to set up a simple apt-repo on the filesystem on developer's machines. That directory is mounted in our vagrant VMs which allows us to build .debs for java projects on our host machines, then install them in our guests. That being the case, we never intended for this plugin to run anywhere besides developer machines. That is was running on Teamcity at all was a mistake.