### PR TITLE
SRE-975 war deploys successfully on mysql 5.7

### DIFF
--- a/db-migrations/01-add-collections/01-add-collections.sql
+++ b/db-migrations/01-add-collections/01-add-collections.sql
@@ -46,7 +46,7 @@ CREATE TABLE IF NOT EXISTS collections (
     versionNumber VARCHAR (255) NOT NULL,
     status TINYINT DEFAULT 0 NOT NULL,
     tag VARCHAR (200),
-    creationDate TIMESTAMP DEFAULT 0,
+    creationDate TIMESTAMP DEFAULT '1970-01-01 00:00:01',
     UNIQUE KEY keySum (bucketId, collkey, versionChecksum),
     PRIMARY KEY (id),
     FOREIGN KEY (bucketId) REFERENCES buckets(bucketId)
@@ -71,7 +71,7 @@ ALTER TABLE buckets
   ADD COLUMN timestamp timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
 
 ALTER TABLE buckets 
-  ADD COLUMN creationDate TIMESTAMP DEFAULT 0;
+  ADD COLUMN creationDate TIMESTAMP DEFAULT '1970-01-01 00:00:01';
 
 UPDATE buckets SET creationDate = CURRENT_TIMESTAMP;
 
@@ -79,7 +79,7 @@ UPDATE buckets SET creationDate = CURRENT_TIMESTAMP;
 # Objects are getting creation dates and a version checksum.
 #
 ALTER TABLE objects 
-  ADD COLUMN creationDate TIMESTAMP DEFAULT 0;
+  ADD COLUMN creationDate TIMESTAMP DEFAULT '1970-01-01 00:00:01';
 
 ALTER TABLE objects 
   ADD COLUMN versionChecksum VARCHAR (255) NOT NULL;

--- a/src/main/resources/setup.mysql
+++ b/src/main/resources/setup.mysql
@@ -39,7 +39,7 @@ CREATE TABLE IF NOT EXISTS buckets (
     bucketName VARCHAR(255) NOT NULL,
     UNIQUE KEY keyBucket (bucketName),
     timestamp timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    creationDate TIMESTAMP DEFAULT 0,
+    creationDate TIMESTAMP DEFAULT '1970-01-01 00:00:01',
     PRIMARY KEY (bucketId)
 );
 
@@ -55,7 +55,7 @@ CREATE TABLE IF NOT EXISTS objects (
     tag VARCHAR (200),
     status TINYINT DEFAULT 0 NOT NULL,
     versionNumber INTEGER NOT NULL,
-    creationDate TIMESTAMP DEFAULT 0,
+    creationDate TIMESTAMP DEFAULT '1970-01-01 00:00:01',
     userMetadata LONGTEXT,
     uuid CHAR(36) NOT NULL,
     UNIQUE KEY ObjkeyUniversalID (bucketId, objkey, uuid),
@@ -71,7 +71,7 @@ CREATE TABLE IF NOT EXISTS collections (
     versionNumber INTEGER NOT NULL,
     status TINYINT DEFAULT 0 NOT NULL,
     tag VARCHAR (200),
-    creationDate TIMESTAMP DEFAULT 0,
+    creationDate TIMESTAMP DEFAULT '1970-01-01 00:00:01',
     userMetadata LONGTEXT,
     uuid CHAR(36) NOT NULL,
     UNIQUE KEY keyVersion (bucketId, collkey, versionNumber),


### PR DESCRIPTION
mysql 5.7 got stricter on timestamp default values, causing the database creation to fail.

see: https://stackoverflow.com/questions/9192027/invalid-default-value-for-create-date-timestamp-field

https://jira.plos.org/jira/browse/SRE-975