### PR TITLE
ENG-343

### DIFF
--- a/gcsmigrate/check-versions.py
+++ b/gcsmigrate/check-versions.py
@@ -1,0 +1,61 @@
+import os
+
+import dj_database_url
+import pymysql
+from tqdm import tqdm
+
+
+def make_db_connection(db_url):
+    config = dj_database_url.parse(db_url)
+    return pymysql.connect(
+        host=config["HOST"],
+        user=config["USER"],
+        password=config["PASSWORD"],
+        db=config["NAME"],
+        cursorclass=pymysql.cursors.SSCursor,
+    )
+
+
+def process_rows(db_url, sql, uuid_dict):
+    connection = make_db_connection(db_url)
+    try:
+        cursor = connection.cursor()
+        cursor.execute(sql)
+        with tqdm(desc=sql) as pbar:
+            row = cursor.fetchone()
+            pbar.update()
+            while row:
+                (key, uuid, size) = row
+                uuid_dict[uuid] = (key, size)
+                row = cursor.fetchone()
+                pbar.update()
+    finally:
+        connection.close()
+
+
+rhino_keys = dict()
+process_rows(
+    os.environ["RHINO_DATABASE_URL"],
+    "select crepoKey, crepoUuid, fileSize from articleFile;",
+    rhino_keys,
+)
+
+contentrepo_keys = dict()
+process_rows(
+    os.environ["CONTENTREPO_DATABASE_URL"],
+    # preprints or corpus bucket
+    "select objKey, uuid, size from objects where bucketId IN (1, 9, 2112);",
+    contentrepo_keys,
+)
+
+
+def check_equal(uuid):
+    rhino = rhino_keys[uuid]
+    contentrepo = contentrepo_keys[uuid]
+    assert (
+        rhino == contentrepo
+    ), f"{key}: rhino ({rhino}) != contentrepo ({contentrepo})"
+
+
+for uuid in rhino_keys.keys():
+    check_equal(uuid)

--- a/gcsmigrate/main.py
+++ b/gcsmigrate/main.py
@@ -1,10 +1,11 @@
+import json
 import base64
 import os
 
 import pymogilefs
 from google.cloud import firestore, storage
 
-from shared import MogileFile, make_bucket_map
+from shared import MogileFile, make_bucket_map, copy_object
 
 COLLECTION_NAME = os.environ["COLLECTION_NAME"]
 BUCKET_MAP = make_bucket_map(os.environ["BUCKETS"])
@@ -25,12 +26,13 @@ def main(event, context):
         )
     )
 
-    data = base64.b64decode(event["data"]).decode("utf-8")
+    json_str = base64.b64decode(event["data"]).decode("utf-8")
+    json_struct = json.loads(json_str)
     action = event["attributes"].get("action")
-    mogile_file = MogileFile.from_json(data)
     collection = firestore_client.collection(COLLECTION_NAME)
 
     if action == "verify":
+        mogile_file = MogileFile.from_json(json_struct)
         doc_ref = collection.document(str(mogile_file.fid))
         doc = doc_ref.get()
         assert doc.exists, f"No db entry for {mogile_file.fid}."
@@ -43,6 +45,12 @@ def main(event, context):
             gcs_client=gcs_client,
         )
     elif action == "migrate":
+        mogile_file = MogileFile.from_json(json_struct)
         mogile_file.migrate(mogile_client, collection, gcs_client, BUCKET_MAP)
+    elif action == "copy":
+        bucket_name = json_struct["bucket"]
+        from_key = json_struct["from_key"]
+        to_key = json_struct["to_key"]
+        copy_object(gcs_client, bucket_name, from_key, to_key)
     else:
         raise Exception(f"Bad action: {action}.")

--- a/gcsmigrate/verify.py
+++ b/gcsmigrate/verify.py
@@ -1,24 +1,11 @@
 import dbm.gnu
 import os
 import sys
-from contextlib import contextmanager
 
 from google.cloud import storage
 from tqdm import tqdm
 
-from shared import get_mogile_files_from_database, make_bucket_map
-
-
-@contextmanager
-def open_db(dbpath):
-    with dbm.gnu.open(dbpath, "cf") as db:
-        try:
-            yield db
-            db.sync()
-        except:
-            # Clean up db if there was an error
-            os.unlink(dbpath)
-            raise
+from shared import get_mogile_files_from_database, make_bucket_map, open_db
 
 
 def load_bucket(bucket_name):


### PR DESCRIPTION
https://jira.plos.org/jira/browse/ENG-343

This is the second stage of our migration, where we copy sha1sum named files to their final location, which is based on the doi, the ingestion number, and the file name.

I ran this migration using production data into a dev GCS bucket. I did this by:

1. deploy the function to GCF using the instructions in the README (https://github.com/plos/content-repo/blob/ENG-343/gcsmigrate/README.md#L18)
2. Run `pipenv run python enqueue.py final_migrate` with the correct settings in `.env` (I actually had to run this on a server in SOMA, my internet connection is too slow):

There are a few things we can test here:

How is the code? Does it look good?

Test the production migration. I have migrated the data (as of a week ago) to a GCS bucket. You can use a local dump of the prod db to test.

Load a prod dump into a local docker container and point it at GCS:
  1. Copy db dump from `journals-prod1-backend1.soma.plos.org:/home/egh/dump.gz` to your local directory
  2. Checkout the `docker` branch of wombat in gitlab
  3. make a small change in `docker-compose.yml` to load the dump:
```patch
diff --git a/docker-compose.yml b/docker-compose.yml
index 1a31dec8f..a5ca91fac 100644
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,8 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_DATABASE: ambra
+    volumes:
+      - ./dump.sql.gz:/docker-entrypoint-initdb.d/dump.sql.gz
 
   memcached:
     image: memcached:latest
```
4. Bring up the db only to load the dump:
```docker-compose up db```
5. (wait a long time, it's a big db). It should say when it's done, but it won't exit. Use ctrl-c to exit.
6. Undo the changes you made to `docker-compose.yml` above.
6. Configure your `.env` in wombat (ask me for this)
7. Bring up the journals stack: `docker-compose up` This will take a while too, because migrations need to run.
8. Navigate to http://localhost:8080/ and click on Plos one
9. Try a random search.
10. Click on an article. It should render